### PR TITLE
feat: add structured output support (added in ollama 0.5.0)

### DIFF
--- a/src/libs/Ollama/Generated/JsonConverters.ResponseFormat.g.cs
+++ b/src/libs/Ollama/Generated/JsonConverters.ResponseFormat.g.cs
@@ -1,9 +1,10 @@
 #nullable enable
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace Ollama.JsonConverters
 {
     /// <inheritdoc />
-    public sealed class ResponseFormatJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Ollama.ResponseFormat>
+    public class ResponseFormatJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Ollama.ResponseFormat>
     {
         /// <inheritdoc />
         public override global::Ollama.ResponseFormat Read(
@@ -11,28 +12,53 @@ namespace Ollama.JsonConverters
             global::System.Type typeToConvert,
             global::System.Text.Json.JsonSerializerOptions options)
         {
-            switch (reader.TokenType)
+            options = options ?? throw new global::System.ArgumentNullException(nameof(options));
+            var typeInfoResolver = options.TypeInfoResolver ?? throw new global::System.InvalidOperationException("TypeInfoResolver is not set.");
+
+            var
+            readerCopy = reader;
+            global::Ollama.ResponseFormatEnum? value1 = default;
+            try
             {
-                case global::System.Text.Json.JsonTokenType.String:
-                {
-                    var stringValue = reader.GetString();
-                    if (stringValue != null)
-                    {
-                        return global::Ollama.ResponseFormatExtensions.ToEnum(stringValue) ?? default;
-                    }
-                    
-                    break;
-                }
-                case global::System.Text.Json.JsonTokenType.Number:
-                {
-                    var numValue = reader.GetInt32();
-                    return (global::Ollama.ResponseFormat)numValue;
-                }
-                default:
-                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Ollama.ResponseFormatEnum), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Ollama.ResponseFormatEnum> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Ollama.ResponseFormatEnum).Name}");
+                value1 = global::System.Text.Json.JsonSerializer.Deserialize(ref readerCopy, typeInfo);
+            }
+            catch (global::System.Text.Json.JsonException)
+            {
             }
 
-            return default;
+            readerCopy = reader;
+            object? value2 = default;
+            try
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(object), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<object> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(object).Name}");
+                value2 = global::System.Text.Json.JsonSerializer.Deserialize(ref readerCopy, typeInfo);
+            }
+            catch (global::System.Text.Json.JsonException)
+            {
+            }
+
+            var result = new global::Ollama.ResponseFormat(
+                value1,
+                value2
+                );
+
+            if (value1 != null)
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Ollama.ResponseFormatEnum), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Ollama.ResponseFormatEnum> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Ollama.ResponseFormatEnum).Name}");
+                _ = global::System.Text.Json.JsonSerializer.Deserialize(ref reader, typeInfo);
+            }
+            else if (value2 != null)
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(object), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<object> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(object).Name}");
+                _ = global::System.Text.Json.JsonSerializer.Deserialize(ref reader, typeInfo);
+            }
+
+            return result;
         }
 
         /// <inheritdoc />
@@ -41,9 +67,21 @@ namespace Ollama.JsonConverters
             global::Ollama.ResponseFormat value,
             global::System.Text.Json.JsonSerializerOptions options)
         {
-            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+            options = options ?? throw new global::System.ArgumentNullException(nameof(options));
+            var typeInfoResolver = options.TypeInfoResolver ?? throw new global::System.InvalidOperationException("TypeInfoResolver is not set.");
 
-            writer.WriteStringValue(global::Ollama.ResponseFormatExtensions.ToValueString(value));
+            if (value.IsValue1)
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(global::Ollama.ResponseFormatEnum), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<global::Ollama.ResponseFormatEnum> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(global::Ollama.ResponseFormatEnum).Name}");
+                global::System.Text.Json.JsonSerializer.Serialize(writer, value.Value1, typeInfo);
+            }
+            else if (value.IsValue2)
+            {
+                var typeInfo = typeInfoResolver.GetTypeInfo(typeof(object), options) as global::System.Text.Json.Serialization.Metadata.JsonTypeInfo<object?> ??
+                               throw new global::System.InvalidOperationException($"Cannot get type info for {typeof(object).Name}");
+                global::System.Text.Json.JsonSerializer.Serialize(writer, value.Value2, typeInfo);
+            }
         }
     }
 }

--- a/src/libs/Ollama/Generated/JsonConverters.ResponseFormatEnum.g.cs
+++ b/src/libs/Ollama/Generated/JsonConverters.ResponseFormatEnum.g.cs
@@ -3,10 +3,10 @@
 namespace Ollama.JsonConverters
 {
     /// <inheritdoc />
-    public sealed class ResponseFormatNullableJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Ollama.ResponseFormat?>
+    public sealed class ResponseFormatEnumJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Ollama.ResponseFormatEnum>
     {
         /// <inheritdoc />
-        public override global::Ollama.ResponseFormat? Read(
+        public override global::Ollama.ResponseFormatEnum Read(
             ref global::System.Text.Json.Utf8JsonReader reader,
             global::System.Type typeToConvert,
             global::System.Text.Json.JsonSerializerOptions options)
@@ -18,7 +18,7 @@ namespace Ollama.JsonConverters
                     var stringValue = reader.GetString();
                     if (stringValue != null)
                     {
-                        return global::Ollama.ResponseFormatExtensions.ToEnum(stringValue);
+                        return global::Ollama.ResponseFormatEnumExtensions.ToEnum(stringValue) ?? default;
                     }
                     
                     break;
@@ -26,7 +26,7 @@ namespace Ollama.JsonConverters
                 case global::System.Text.Json.JsonTokenType.Number:
                 {
                     var numValue = reader.GetInt32();
-                    return (global::Ollama.ResponseFormat)numValue;
+                    return (global::Ollama.ResponseFormatEnum)numValue;
                 }
                 default:
                     throw new global::System.ArgumentOutOfRangeException(nameof(reader));
@@ -38,19 +38,12 @@ namespace Ollama.JsonConverters
         /// <inheritdoc />
         public override void Write(
             global::System.Text.Json.Utf8JsonWriter writer,
-            global::Ollama.ResponseFormat? value,
+            global::Ollama.ResponseFormatEnum value,
             global::System.Text.Json.JsonSerializerOptions options)
         {
             writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
 
-            if (value == null)
-            {
-                writer.WriteNullValue();
-            }
-            else
-            {
-                writer.WriteStringValue(global::Ollama.ResponseFormatExtensions.ToValueString(value.Value));
-            }
+            writer.WriteStringValue(global::Ollama.ResponseFormatEnumExtensions.ToValueString(value));
         }
     }
 }

--- a/src/libs/Ollama/Generated/JsonConverters.ResponseFormatEnumNullable.g.cs
+++ b/src/libs/Ollama/Generated/JsonConverters.ResponseFormatEnumNullable.g.cs
@@ -1,0 +1,56 @@
+#nullable enable
+
+namespace Ollama.JsonConverters
+{
+    /// <inheritdoc />
+    public sealed class ResponseFormatEnumNullableJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Ollama.ResponseFormatEnum?>
+    {
+        /// <inheritdoc />
+        public override global::Ollama.ResponseFormatEnum? Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case global::System.Text.Json.JsonTokenType.String:
+                {
+                    var stringValue = reader.GetString();
+                    if (stringValue != null)
+                    {
+                        return global::Ollama.ResponseFormatEnumExtensions.ToEnum(stringValue);
+                    }
+                    
+                    break;
+                }
+                case global::System.Text.Json.JsonTokenType.Number:
+                {
+                    var numValue = reader.GetInt32();
+                    return (global::Ollama.ResponseFormatEnum)numValue;
+                }
+                default:
+                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Ollama.ResponseFormatEnum? value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+
+            if (value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStringValue(global::Ollama.ResponseFormatEnumExtensions.ToValueString(value.Value));
+            }
+        }
+    }
+}

--- a/src/libs/Ollama/Generated/JsonSerializerContext.g.cs
+++ b/src/libs/Ollama/Generated/JsonSerializerContext.g.cs
@@ -13,8 +13,8 @@ namespace Ollama
         DefaultIgnoreCondition = global::System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
         Converters = new global::System.Type[] 
         { 
-            typeof(global::Ollama.JsonConverters.ResponseFormatJsonConverter),
-            typeof(global::Ollama.JsonConverters.ResponseFormatNullableJsonConverter),
+            typeof(global::Ollama.JsonConverters.ResponseFormatEnumJsonConverter),
+            typeof(global::Ollama.JsonConverters.ResponseFormatEnumNullableJsonConverter),
             typeof(global::Ollama.JsonConverters.MessageRoleJsonConverter),
             typeof(global::Ollama.JsonConverters.MessageRoleNullableJsonConverter),
             typeof(global::Ollama.JsonConverters.ToolTypeJsonConverter),
@@ -27,6 +27,7 @@ namespace Ollama
             typeof(global::Ollama.JsonConverters.PullModelStatusEnumNullableJsonConverter),
             typeof(global::Ollama.JsonConverters.PushModelResponseStatusJsonConverter),
             typeof(global::Ollama.JsonConverters.PushModelResponseStatusNullableJsonConverter),
+            typeof(global::Ollama.JsonConverters.ResponseFormatJsonConverter),
             typeof(global::Ollama.JsonConverters.DoneReasonJsonConverter),
             typeof(global::Ollama.JsonConverters.CreateModelStatusJsonConverter),
             typeof(global::Ollama.JsonConverters.PullModelStatusJsonConverter),

--- a/src/libs/Ollama/Generated/JsonSerializerContextTypes.g.cs
+++ b/src/libs/Ollama/Generated/JsonSerializerContextTypes.g.cs
@@ -66,190 +66,194 @@ namespace Ollama
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.VersionResponse? Type10 { get; set; }
+        public global::Ollama.ResponseFormatEnum? Type10 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.GenerateCompletionResponse? Type11 { get; set; }
+        public object? Type11 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.DateTime? Type12 { get; set; }
+        public global::Ollama.VersionResponse? Type12 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.GenerateChatCompletionRequest? Type13 { get; set; }
+        public global::Ollama.GenerateCompletionResponse? Type13 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Ollama.Message>? Type14 { get; set; }
+        public global::System.DateTime? Type14 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.Message? Type15 { get; set; }
+        public global::Ollama.GenerateChatCompletionRequest? Type15 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.MessageRole? Type16 { get; set; }
+        public global::System.Collections.Generic.IList<global::Ollama.Message>? Type16 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Ollama.ToolCall>? Type17 { get; set; }
+        public global::Ollama.Message? Type17 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.ToolCall? Type18 { get; set; }
+        public global::Ollama.MessageRole? Type18 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.ToolCallFunction? Type19 { get; set; }
+        public global::System.Collections.Generic.IList<global::Ollama.ToolCall>? Type19 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public object? Type20 { get; set; }
+        public global::Ollama.ToolCall? Type20 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Ollama.Tool>? Type21 { get; set; }
+        public global::Ollama.ToolCallFunction? Type21 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.Tool? Type22 { get; set; }
+        public global::System.Collections.Generic.IList<global::Ollama.Tool>? Type22 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.ToolType? Type23 { get; set; }
+        public global::Ollama.Tool? Type23 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.ToolFunction? Type24 { get; set; }
+        public global::Ollama.ToolType? Type24 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.GenerateChatCompletionResponse? Type25 { get; set; }
+        public global::Ollama.ToolFunction? Type25 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.DoneReason? Type26 { get; set; }
+        public global::Ollama.GenerateChatCompletionResponse? Type26 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.DoneReasonEnum? Type27 { get; set; }
+        public global::Ollama.DoneReason? Type27 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.GenerateEmbeddingRequest? Type28 { get; set; }
+        public global::Ollama.DoneReasonEnum? Type28 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.GenerateEmbeddingResponse? Type29 { get; set; }
+        public global::Ollama.GenerateEmbeddingRequest? Type29 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<double>? Type30 { get; set; }
+        public global::Ollama.GenerateEmbeddingResponse? Type30 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public double? Type31 { get; set; }
+        public global::System.Collections.Generic.IList<double>? Type31 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.CreateModelRequest? Type32 { get; set; }
+        public double? Type32 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.CreateModelResponse? Type33 { get; set; }
+        public global::Ollama.CreateModelRequest? Type33 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.CreateModelStatus? Type34 { get; set; }
+        public global::Ollama.CreateModelResponse? Type34 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.CreateModelStatusEnum? Type35 { get; set; }
+        public global::Ollama.CreateModelStatus? Type35 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.ModelsResponse? Type36 { get; set; }
+        public global::Ollama.CreateModelStatusEnum? Type36 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Ollama.Model>? Type37 { get; set; }
+        public global::Ollama.ModelsResponse? Type37 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.Model? Type38 { get; set; }
+        public global::System.Collections.Generic.IList<global::Ollama.Model>? Type38 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.ModelDetails? Type39 { get; set; }
+        public global::Ollama.Model? Type39 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.ModelInformation? Type40 { get; set; }
+        public global::Ollama.ModelDetails? Type40 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.ProcessResponse? Type41 { get; set; }
+        public global::Ollama.ModelInformation? Type41 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Ollama.ProcessModel>? Type42 { get; set; }
+        public global::Ollama.ProcessResponse? Type42 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.ProcessModel? Type43 { get; set; }
+        public global::System.Collections.Generic.IList<global::Ollama.ProcessModel>? Type43 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.ModelInfoRequest? Type44 { get; set; }
+        public global::Ollama.ProcessModel? Type44 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.ModelInfo? Type45 { get; set; }
+        public global::Ollama.ModelInfoRequest? Type45 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.CopyModelRequest? Type46 { get; set; }
+        public global::Ollama.ModelInfo? Type46 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.DeleteModelRequest? Type47 { get; set; }
+        public global::Ollama.CopyModelRequest? Type47 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.PullModelRequest? Type48 { get; set; }
+        public global::Ollama.DeleteModelRequest? Type48 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.PullModelResponse? Type49 { get; set; }
+        public global::Ollama.PullModelRequest? Type49 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.PullModelStatus? Type50 { get; set; }
+        public global::Ollama.PullModelResponse? Type50 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.PullModelStatusEnum? Type51 { get; set; }
+        public global::Ollama.PullModelStatus? Type51 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.PushModelRequest? Type52 { get; set; }
+        public global::Ollama.PullModelStatusEnum? Type52 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.PushModelResponse? Type53 { get; set; }
+        public global::Ollama.PushModelRequest? Type53 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.AnyOf<string, global::Ollama.PushModelResponseStatus?>? Type54 { get; set; }
+        public global::Ollama.PushModelResponse? Type54 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.PushModelResponseStatus? Type55 { get; set; }
+        public global::Ollama.AnyOf<string, global::Ollama.PushModelResponseStatus?>? Type55 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public byte[]? Type56 { get; set; }
+        public global::Ollama.PushModelResponseStatus? Type56 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public byte[]? Type57 { get; set; }
     }
 }

--- a/src/libs/Ollama/Generated/Ollama.ChatClient.GenerateChatCompletion.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.ChatClient.GenerateChatCompletion.g.cs
@@ -115,11 +115,7 @@ namespace Ollama
         /// <param name="messages">
         /// The messages of the chat, this can be used to keep a chat memory
         /// </param>
-        /// <param name="format">
-        /// The format to return a response in. Currently the only accepted value is json.<br/>
-        /// Enable JSON mode by setting the format parameter to json. This will structure the response as valid JSON.<br/>
-        /// Note: it's important to instruct the model to use JSON in the prompt. Otherwise, the model may generate large amounts whitespace.
-        /// </param>
+        /// <param name="format"></param>
         /// <param name="options">
         /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
         /// </param>

--- a/src/libs/Ollama/Generated/Ollama.CompletionsClient.GenerateCompletion.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.CompletionsClient.GenerateCompletion.g.cs
@@ -134,11 +134,7 @@ namespace Ollama
         /// <param name="options">
         /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
         /// </param>
-        /// <param name="format">
-        /// The format to return a response in. Currently the only accepted value is json.<br/>
-        /// Enable JSON mode by setting the format parameter to json. This will structure the response as valid JSON.<br/>
-        /// Note: it's important to instruct the model to use JSON in the prompt. Otherwise, the model may generate large amounts whitespace.
-        /// </param>
+        /// <param name="format"></param>
         /// <param name="raw">
         /// If `true` no formatting will be applied to the prompt and no context will be returned. <br/>
         /// You may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API, and are managing history yourself.

--- a/src/libs/Ollama/Generated/Ollama.IChatClient.GenerateChatCompletion.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.IChatClient.GenerateChatCompletion.g.cs
@@ -27,11 +27,7 @@ namespace Ollama
         /// <param name="messages">
         /// The messages of the chat, this can be used to keep a chat memory
         /// </param>
-        /// <param name="format">
-        /// The format to return a response in. Currently the only accepted value is json.<br/>
-        /// Enable JSON mode by setting the format parameter to json. This will structure the response as valid JSON.<br/>
-        /// Note: it's important to instruct the model to use JSON in the prompt. Otherwise, the model may generate large amounts whitespace.
-        /// </param>
+        /// <param name="format"></param>
         /// <param name="options">
         /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
         /// </param>

--- a/src/libs/Ollama/Generated/Ollama.ICompletionsClient.GenerateCompletion.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.ICompletionsClient.GenerateCompletion.g.cs
@@ -46,11 +46,7 @@ namespace Ollama
         /// <param name="options">
         /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
         /// </param>
-        /// <param name="format">
-        /// The format to return a response in. Currently the only accepted value is json.<br/>
-        /// Enable JSON mode by setting the format parameter to json. This will structure the response as valid JSON.<br/>
-        /// Note: it's important to instruct the model to use JSON in the prompt. Otherwise, the model may generate large amounts whitespace.
-        /// </param>
+        /// <param name="format"></param>
         /// <param name="raw">
         /// If `true` no formatting will be applied to the prompt and no context will be returned. <br/>
         /// You may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API, and are managing history yourself.

--- a/src/libs/Ollama/Generated/Ollama.Models.GenerateChatCompletionRequest.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.Models.GenerateChatCompletionRequest.g.cs
@@ -26,9 +26,7 @@ namespace Ollama
         public required global::System.Collections.Generic.IList<global::Ollama.Message> Messages { get; set; }
 
         /// <summary>
-        /// The format to return a response in. Currently the only accepted value is json.<br/>
-        /// Enable JSON mode by setting the format parameter to json. This will structure the response as valid JSON.<br/>
-        /// Note: it's important to instruct the model to use JSON in the prompt. Otherwise, the model may generate large amounts whitespace.
+        /// 
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("format")]
         [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Ollama.JsonConverters.ResponseFormatJsonConverter))]
@@ -80,11 +78,7 @@ namespace Ollama
         /// <param name="messages">
         /// The messages of the chat, this can be used to keep a chat memory
         /// </param>
-        /// <param name="format">
-        /// The format to return a response in. Currently the only accepted value is json.<br/>
-        /// Enable JSON mode by setting the format parameter to json. This will structure the response as valid JSON.<br/>
-        /// Note: it's important to instruct the model to use JSON in the prompt. Otherwise, the model may generate large amounts whitespace.
-        /// </param>
+        /// <param name="format"></param>
         /// <param name="options">
         /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
         /// </param>

--- a/src/libs/Ollama/Generated/Ollama.Models.GenerateCompletionRequest.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.Models.GenerateCompletionRequest.g.cs
@@ -64,9 +64,7 @@ namespace Ollama
         public global::Ollama.RequestOptions? Options { get; set; }
 
         /// <summary>
-        /// The format to return a response in. Currently the only accepted value is json.<br/>
-        /// Enable JSON mode by setting the format parameter to json. This will structure the response as valid JSON.<br/>
-        /// Note: it's important to instruct the model to use JSON in the prompt. Otherwise, the model may generate large amounts whitespace.
+        /// 
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("format")]
         [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Ollama.JsonConverters.ResponseFormatJsonConverter))]
@@ -132,11 +130,7 @@ namespace Ollama
         /// <param name="options">
         /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
         /// </param>
-        /// <param name="format">
-        /// The format to return a response in. Currently the only accepted value is json.<br/>
-        /// Enable JSON mode by setting the format parameter to json. This will structure the response as valid JSON.<br/>
-        /// Note: it's important to instruct the model to use JSON in the prompt. Otherwise, the model may generate large amounts whitespace.
-        /// </param>
+        /// <param name="format"></param>
         /// <param name="raw">
         /// If `true` no formatting will be applied to the prompt and no context will be returned. <br/>
         /// You may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API, and are managing history yourself.

--- a/src/libs/Ollama/Generated/Ollama.Models.ResponseFormat.Json.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.Models.ResponseFormat.Json.g.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+namespace Ollama
+{
+    public readonly partial struct ResponseFormat
+    {
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public string ToJson(
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                this.GetType(),
+                jsonSerializerContext);
+        }
+
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public string ToJson(
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public static global::Ollama.ResponseFormat? FromJson(
+            string json,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize(
+                json,
+                typeof(global::Ollama.ResponseFormat),
+                jsonSerializerContext) as global::Ollama.ResponseFormat?;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::Ollama.ResponseFormat? FromJson(
+            string json,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::Ollama.ResponseFormat>(
+                json,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerContext.
+        /// </summary>
+        public static async global::System.Threading.Tasks.ValueTask<global::Ollama.ResponseFormat?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
+                jsonStream,
+                typeof(global::Ollama.ResponseFormat),
+                jsonSerializerContext).ConfigureAwait(false)) as global::Ollama.ResponseFormat?;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::System.Threading.Tasks.ValueTask<global::Ollama.ResponseFormat?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Ollama.ResponseFormat?>(
+                jsonStream,
+                jsonSerializerOptions);
+        }
+    }
+}

--- a/src/libs/Ollama/Generated/Ollama.Models.ResponseFormat.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.Models.ResponseFormat.g.cs
@@ -1,47 +1,204 @@
+#pragma warning disable CS0618 // Type or member is obsolete
 
 #nullable enable
 
 namespace Ollama
 {
     /// <summary>
-    /// The format to return a response in. Currently the only accepted value is json.<br/>
-    /// Enable JSON mode by setting the format parameter to json. This will structure the response as valid JSON.<br/>
-    /// Note: it's important to instruct the model to use JSON in the prompt. Otherwise, the model may generate large amounts whitespace.
+    /// 
     /// </summary>
-    public enum ResponseFormat
+    public readonly partial struct ResponseFormat : global::System.IEquatable<ResponseFormat>
     {
+        /// <summary>
+        /// Enable JSON mode by setting the format parameter to 'json'. This will structure the response as valid JSON.
+        /// </summary>
+#if NET6_0_OR_GREATER
+        public global::Ollama.ResponseFormatEnum? Value1 { get; init; }
+#else
+        public global::Ollama.ResponseFormatEnum? Value1 { get; }
+#endif
+
         /// <summary>
         /// 
         /// </summary>
-        Json,
-    }
+#if NET6_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof(Value1))]
+#endif
+        public bool IsValue1 => Value1 != null;
 
-    /// <summary>
-    /// Enum extensions to do fast conversions without the reflection.
-    /// </summary>
-    public static class ResponseFormatExtensions
-    {
         /// <summary>
-        /// Converts an enum to a string.
+        /// 
         /// </summary>
-        public static string ToValueString(this ResponseFormat value)
+        public static implicit operator ResponseFormat(global::Ollama.ResponseFormatEnum value) => new ResponseFormat(value);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static implicit operator global::Ollama.ResponseFormatEnum?(ResponseFormat @this) => @this.Value1;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public ResponseFormat(global::Ollama.ResponseFormatEnum? value)
         {
-            return value switch
-            {
-                ResponseFormat.Json => "json",
-                _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
-            };
+            Value1 = value;
         }
+
         /// <summary>
-        /// Converts an string to a enum.
+        /// A JSON Schema object that defines the structure of the response. The model will generate a response that matches this schema.
         /// </summary>
-        public static ResponseFormat? ToEnum(string value)
+#if NET6_0_OR_GREATER
+        public object? Value2 { get; init; }
+#else
+        public object? Value2 { get; }
+#endif
+
+        /// <summary>
+        /// 
+        /// </summary>
+#if NET6_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof(Value2))]
+#endif
+        public bool IsValue2 => Value2 != null;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public ResponseFormat(object? value)
         {
-            return value switch
+            Value2 = value;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public ResponseFormat(
+            global::Ollama.ResponseFormatEnum? value1,
+            object? value2
+            )
+        {
+            Value1 = value1;
+            Value2 = value2;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public object? Object =>
+            Value2 as object ??
+            Value1 as object 
+            ;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool Validate()
+        {
+            return IsValue1 && !IsValue2 || !IsValue1 && IsValue2;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public TResult? Match<TResult>(
+            global::System.Func<global::Ollama.ResponseFormatEnum?, TResult>? value1 = null,
+            global::System.Func<object?, TResult>? value2 = null,
+            bool validate = true)
+        {
+            if (validate)
             {
-                "json" => ResponseFormat.Json,
-                _ => null,
+                Validate();
+            }
+
+            if (IsValue1 && value1 != null)
+            {
+                return value1(Value1!);
+            }
+            else if (IsValue2 && value2 != null)
+            {
+                return value2(Value2!);
+            }
+
+            return default(TResult);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void Match(
+            global::System.Action<global::Ollama.ResponseFormatEnum?>? value1 = null,
+            global::System.Action<object?>? value2 = null,
+            bool validate = true)
+        {
+            if (validate)
+            {
+                Validate();
+            }
+
+            if (IsValue1)
+            {
+                value1?.Invoke(Value1!);
+            }
+            else if (IsValue2)
+            {
+                value2?.Invoke(Value2!);
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public override int GetHashCode()
+        {
+            var fields = new object?[]
+            {
+                Value1,
+                typeof(global::Ollama.ResponseFormatEnum),
+                Value2,
+                typeof(object),
             };
+            const int offset = unchecked((int)2166136261);
+            const int prime = 16777619;
+            static int HashCodeAggregator(int hashCode, object? value) => value == null
+                ? (hashCode ^ 0) * prime
+                : (hashCode ^ value.GetHashCode()) * prime;
+
+            return global::System.Linq.Enumerable.Aggregate(fields, offset, HashCodeAggregator);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool Equals(ResponseFormat other)
+        {
+            return
+                global::System.Collections.Generic.EqualityComparer<global::Ollama.ResponseFormatEnum?>.Default.Equals(Value1, other.Value1) &&
+                global::System.Collections.Generic.EqualityComparer<object?>.Default.Equals(Value2, other.Value2) 
+                ;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static bool operator ==(ResponseFormat obj1, ResponseFormat obj2)
+        {
+            return global::System.Collections.Generic.EqualityComparer<ResponseFormat>.Default.Equals(obj1, obj2);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static bool operator !=(ResponseFormat obj1, ResponseFormat obj2)
+        {
+            return !(obj1 == obj2);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public override bool Equals(object? obj)
+        {
+            return obj is ResponseFormat o && Equals(o);
         }
     }
 }

--- a/src/libs/Ollama/Generated/Ollama.Models.ResponseFormatEnum.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.Models.ResponseFormatEnum.g.cs
@@ -1,0 +1,45 @@
+
+#nullable enable
+
+namespace Ollama
+{
+    /// <summary>
+    /// Enable JSON mode by setting the format parameter to 'json'. This will structure the response as valid JSON.
+    /// </summary>
+    public enum ResponseFormatEnum
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        Json,
+    }
+
+    /// <summary>
+    /// Enum extensions to do fast conversions without the reflection.
+    /// </summary>
+    public static class ResponseFormatEnumExtensions
+    {
+        /// <summary>
+        /// Converts an enum to a string.
+        /// </summary>
+        public static string ToValueString(this ResponseFormatEnum value)
+        {
+            return value switch
+            {
+                ResponseFormatEnum.Json => "json",
+                _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
+            };
+        }
+        /// <summary>
+        /// Converts an string to a enum.
+        /// </summary>
+        public static ResponseFormatEnum? ToEnum(string value)
+        {
+            return value switch
+            {
+                "json" => ResponseFormatEnum.Json,
+                _ => null,
+            };
+        }
+    }
+}

--- a/src/libs/Ollama/Generated/Ollama.Models.ResponseFormatEnum2.Json.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.Models.ResponseFormatEnum2.Json.g.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+namespace Ollama
+{
+    public sealed partial class ResponseFormatEnum2
+    {
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public string ToJson(
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                this.GetType(),
+                jsonSerializerContext);
+        }
+
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public string ToJson(
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public static global::Ollama.ResponseFormatEnum2? FromJson(
+            string json,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize(
+                json,
+                typeof(global::Ollama.ResponseFormatEnum2),
+                jsonSerializerContext) as global::Ollama.ResponseFormatEnum2;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::Ollama.ResponseFormatEnum2? FromJson(
+            string json,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::Ollama.ResponseFormatEnum2>(
+                json,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerContext.
+        /// </summary>
+        public static async global::System.Threading.Tasks.ValueTask<global::Ollama.ResponseFormatEnum2?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
+                jsonStream,
+                typeof(global::Ollama.ResponseFormatEnum2),
+                jsonSerializerContext).ConfigureAwait(false)) as global::Ollama.ResponseFormatEnum2;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::System.Threading.Tasks.ValueTask<global::Ollama.ResponseFormatEnum2?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Ollama.ResponseFormatEnum2?>(
+                jsonStream,
+                jsonSerializerOptions);
+        }
+    }
+}

--- a/src/libs/Ollama/Generated/Ollama.Models.ResponseFormatEnum2.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.Models.ResponseFormatEnum2.g.cs
@@ -1,0 +1,18 @@
+
+#nullable enable
+
+namespace Ollama
+{
+    /// <summary>
+    /// A JSON Schema object that defines the structure of the response. The model will generate a response that matches this schema.
+    /// </summary>
+    public sealed partial class ResponseFormatEnum2
+    {
+
+        /// <summary>
+        /// Additional properties that are not explicitly defined in the schema
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonExtensionData]
+        public global::System.Collections.Generic.IDictionary<string, object> AdditionalProperties { get; set; } = new global::System.Collections.Generic.Dictionary<string, object>();
+    }
+}

--- a/src/libs/Ollama/generate.sh
+++ b/src/libs/Ollama/generate.sh
@@ -1,7 +1,7 @@
 dotnet tool install --global autosdk.cli --prerelease
 rm -rf Generated
-#curl -o openapi.yaml https://raw.githubusercontent.com/davidmigloz/langchain_dart/main/packages/ollama_dart/oas/ollama-curated.yaml
-#dotnet run --project ../../helpers/FixOpenApiSpec openapi.yaml
+curl -o openapi.yaml https://raw.githubusercontent.com/davidmigloz/langchain_dart/main/packages/ollama_dart/oas/ollama-curated.yaml
+dotnet run --project ../../helpers/FixOpenApiSpec openapi.yaml
 if [ $? -ne 0 ]; then
  echo "Failed, exiting..."
  exit 1

--- a/src/libs/Ollama/generate.sh
+++ b/src/libs/Ollama/generate.sh
@@ -1,7 +1,7 @@
 dotnet tool install --global autosdk.cli --prerelease
 rm -rf Generated
-curl -o openapi.yaml https://raw.githubusercontent.com/davidmigloz/langchain_dart/main/packages/ollama_dart/oas/ollama-curated.yaml
-dotnet run --project ../../helpers/FixOpenApiSpec openapi.yaml
+#curl -o openapi.yaml https://raw.githubusercontent.com/davidmigloz/langchain_dart/main/packages/ollama_dart/oas/ollama-curated.yaml
+#dotnet run --project ../../helpers/FixOpenApiSpec openapi.yaml
 if [ $? -ne 0 ]; then
  echo "Failed, exiting..."
  exit 1

--- a/src/libs/Ollama/openapi.yaml
+++ b/src/libs/Ollama/openapi.yaml
@@ -438,10 +438,13 @@ components:
           nullable: true
       description: Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
     ResponseFormat:
-      enum:
-        - json
-      type: string
-      description: "The format to return a response in. Currently the only accepted value is json.\n\nEnable JSON mode by setting the format parameter to json. This will structure the response as valid JSON.\n\nNote: it's important to instruct the model to use JSON in the prompt. Otherwise, the model may generate large amounts whitespace.\n"
+      oneOf:
+        - type: string
+          enum: ['json']
+          description: "Enable JSON mode by setting the format parameter to 'json'. This will structure the response as valid JSON."
+        - type: object
+          description: "A JSON Schema object that defines the structure of the response. The model will generate a response that matches this schema."
+          additionalProperties: true
     VersionResponse:
       type: object
       properties:

--- a/src/tests/Ollama.IntegrationTests/Test.StructuredOutputInChat.cs
+++ b/src/tests/Ollama.IntegrationTests/Test.StructuredOutputInChat.cs
@@ -1,0 +1,71 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+namespace Ollama.IntegrationTests;
+
+public partial class Tests
+{
+    [TestMethod]
+    public async Task StructuredOutputInChat()
+    {
+#if DEBUG
+        await using var container = await Environment.PrepareAsync(EnvironmentType.Local, "llama3.2");
+#else
+        await using var container = await Environment.PrepareAsync(EnvironmentType.Container, "llama3.2");
+#endif
+
+        var chat = container.ApiClient.Chat(
+            model: "llama3.2",
+            systemMessage: "You are a helpful weather assistant."
+        );
+
+        // can also use NewtonSoft.Json.Schema or some other auto schema generation library
+        var schemaObject = JsonSerializer.Deserialize<object>(@"{
+            ""description"": ""The response to a query about the weather"",
+            ""type"": ""object"",
+            ""required"": [""Temperature"", ""Location"", ""Unit""],
+            ""properties"": {
+                ""Temperature"": {
+                    ""type"": ""integer""
+                },
+                ""Location"": {
+                    ""type"": ""string""
+                },
+                ""Unit"": {
+                    ""type"": ""string"",
+                    ""enum"": [""Celsius"", ""Fahrenheit""]
+                }
+            }
+        }");
+
+        try
+        {
+            Console.WriteLine($"schemaObject: {schemaObject}");
+            chat.ResponseFormat = new ResponseFormat(schemaObject);
+            var response = await chat.SendAsync("What is the current temperature in Dubai, UAE in Celsius? (hint: it's 25C in Dubai right now)");
+            Console.WriteLine(response);
+            var queryResponse = JsonSerializer.Deserialize<QueryResponse>(response.Content);
+            queryResponse.Should().NotBeNull();
+            queryResponse.Temperature.Should().Be(25);
+            queryResponse.Location.Should().Contain("Dubai");
+        }
+        finally
+        {
+            Console.WriteLine(chat.PrintMessages());
+        }
+    }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum TemperatureUnit
+    {
+        Celsius,
+        Fahrenheit
+    }
+
+    public class QueryResponse {
+
+        public int Temperature { get; set; }
+        public TemperatureUnit Unit { get; set; }
+        public string Location { get; set; }
+    }
+}


### PR DESCRIPTION
- Updated `openai.yaml` to allow either the string 'json' or a json-serializable object that represents a json schema (no schema validation occurs).
- added `StructuredOutputInChat` integration test.

Main outstanding issue is that the current `generate.sh` script as it stands will blow away the changes I made to the repos `openapi.yaml` file.  IMO, the generate.sh script should target the repos version of the `openapi.yaml` file and not try to redownload it from the other source.

Addresses issue: https://github.com/tryAGI/Ollama/issues/85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced API response formatting to now support both a simplified JSON mode and an extended schema-based structure, offering added flexibility for API responses.

- **Tests**
  - Introduced integration tests to verify that chat interactions return structured outputs with accurate temperature and location details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->