### PR TITLE
feat:Update OpenAPI spec to add thinking feature and image support for endpoints

### DIFF
--- a/src/libs/Ollama/Generated/Ollama.ChatClient.GenerateChatCompletion.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.ChatClient.GenerateChatCompletion.g.cs
@@ -119,14 +119,11 @@ namespace Ollama
         /// <param name="messages">
         /// The messages of the chat, this can be used to keep a chat memory
         /// </param>
-        /// <param name="format"></param>
-        /// <param name="options">
-        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
-        /// </param>
         /// <param name="stream">
         /// If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.<br/>
         /// Default Value: true
         /// </param>
+        /// <param name="format"></param>
         /// <param name="keepAlive">
         /// How long (in minutes) to keep the model loaded in memory.<br/>
         /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.<br/>
@@ -137,27 +134,38 @@ namespace Ollama
         /// <param name="tools">
         /// A list of tools the model may call.
         /// </param>
+        /// <param name="options">
+        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
+        /// </param>
+        /// <param name="think">
+        /// Think controls whether thinking/reasoning models will think before<br/>
+        /// responding. Needs to be a pointer so we can distinguish between false<br/>
+        /// (request that thinking _not_ be used) and unset (use the old behavior<br/>
+        /// before this option was introduced).
+        /// </param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         public async global::System.Collections.Generic.IAsyncEnumerable<global::Ollama.GenerateChatCompletionResponse> GenerateChatCompletionAsync(
             string model,
             global::System.Collections.Generic.IList<global::Ollama.Message> messages,
-            global::Ollama.ResponseFormat? format = default,
-            global::Ollama.RequestOptions? options = default,
             bool? stream = default,
+            global::Ollama.ResponseFormat? format = default,
             int? keepAlive = default,
             global::System.Collections.Generic.IList<global::Ollama.Tool>? tools = default,
+            global::Ollama.RequestOptions? options = default,
+            bool? think = default,
             [global::System.Runtime.CompilerServices.EnumeratorCancellation] global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::Ollama.GenerateChatCompletionRequest
             {
                 Model = model,
                 Messages = messages,
-                Format = format,
-                Options = options,
                 Stream = stream,
+                Format = format,
                 KeepAlive = keepAlive,
                 Tools = tools,
+                Options = options,
+                Think = think,
             };
 
             var __enumerable = GenerateChatCompletionAsync(

--- a/src/libs/Ollama/Generated/Ollama.CompletionsClient.GenerateCompletion.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.CompletionsClient.GenerateCompletion.g.cs
@@ -123,9 +123,6 @@ namespace Ollama
         /// <param name="suffix">
         /// The text that comes after the inserted text.
         /// </param>
-        /// <param name="images">
-        /// (optional) a list of Base64-encoded images to include in the message (for multimodal models such as llava)
-        /// </param>
         /// <param name="system">
         /// The system prompt to (overrides what is defined in the Modelfile).
         /// </param>
@@ -135,18 +132,15 @@ namespace Ollama
         /// <param name="context">
         /// The context parameter returned from a previous request to [generateCompletion], this can be used to keep a short conversational memory.
         /// </param>
-        /// <param name="options">
-        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
-        /// </param>
-        /// <param name="format"></param>
-        /// <param name="raw">
-        /// If `true` no formatting will be applied to the prompt and no context will be returned. <br/>
-        /// You may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API, and are managing history yourself.
-        /// </param>
         /// <param name="stream">
         /// If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.<br/>
         /// Default Value: true
         /// </param>
+        /// <param name="raw">
+        /// If `true` no formatting will be applied to the prompt and no context will be returned. <br/>
+        /// You may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API, and are managing history yourself.
+        /// </param>
+        /// <param name="format"></param>
         /// <param name="keepAlive">
         /// How long (in minutes) to keep the model loaded in memory.<br/>
         /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.<br/>
@@ -154,21 +148,34 @@ namespace Ollama
         /// - If set to 0, the model will be unloaded immediately once finished.<br/>
         /// - If not set, the model will stay loaded for 5 minutes by default
         /// </param>
+        /// <param name="images">
+        /// (optional) a list of Base64-encoded images to include in the message (for multimodal models such as llava)
+        /// </param>
+        /// <param name="options">
+        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
+        /// </param>
+        /// <param name="think">
+        /// Think controls whether thinking/reasoning models will think before<br/>
+        /// responding. Needs to be a pointer so we can distinguish between false<br/>
+        /// (request that thinking _not_ be used) and unset (use the old behavior<br/>
+        /// before this option was introduced).
+        /// </param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         public async global::System.Collections.Generic.IAsyncEnumerable<global::Ollama.GenerateCompletionResponse> GenerateCompletionAsync(
             string model,
             string prompt,
             string? suffix = default,
-            global::System.Collections.Generic.IList<string>? images = default,
             string? system = default,
             string? template = default,
             global::System.Collections.Generic.IList<long>? context = default,
-            global::Ollama.RequestOptions? options = default,
-            global::Ollama.ResponseFormat? format = default,
-            bool? raw = default,
             bool? stream = default,
+            bool? raw = default,
+            global::Ollama.ResponseFormat? format = default,
             int? keepAlive = default,
+            global::System.Collections.Generic.IList<string>? images = default,
+            global::Ollama.RequestOptions? options = default,
+            bool? think = default,
             [global::System.Runtime.CompilerServices.EnumeratorCancellation] global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::Ollama.GenerateCompletionRequest
@@ -176,15 +183,16 @@ namespace Ollama
                 Model = model,
                 Prompt = prompt,
                 Suffix = suffix,
-                Images = images,
                 System = system,
                 Template = template,
                 Context = context,
-                Options = options,
-                Format = format,
-                Raw = raw,
                 Stream = stream,
+                Raw = raw,
+                Format = format,
                 KeepAlive = keepAlive,
+                Images = images,
+                Options = options,
+                Think = think,
             };
 
             var __enumerable = GenerateCompletionAsync(

--- a/src/libs/Ollama/Generated/Ollama.IChatClient.GenerateChatCompletion.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.IChatClient.GenerateChatCompletion.g.cs
@@ -27,14 +27,11 @@ namespace Ollama
         /// <param name="messages">
         /// The messages of the chat, this can be used to keep a chat memory
         /// </param>
-        /// <param name="format"></param>
-        /// <param name="options">
-        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
-        /// </param>
         /// <param name="stream">
         /// If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.<br/>
         /// Default Value: true
         /// </param>
+        /// <param name="format"></param>
         /// <param name="keepAlive">
         /// How long (in minutes) to keep the model loaded in memory.<br/>
         /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.<br/>
@@ -45,16 +42,26 @@ namespace Ollama
         /// <param name="tools">
         /// A list of tools the model may call.
         /// </param>
+        /// <param name="options">
+        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
+        /// </param>
+        /// <param name="think">
+        /// Think controls whether thinking/reasoning models will think before<br/>
+        /// responding. Needs to be a pointer so we can distinguish between false<br/>
+        /// (request that thinking _not_ be used) and unset (use the old behavior<br/>
+        /// before this option was introduced).
+        /// </param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         global::System.Collections.Generic.IAsyncEnumerable<global::Ollama.GenerateChatCompletionResponse> GenerateChatCompletionAsync(
             string model,
             global::System.Collections.Generic.IList<global::Ollama.Message> messages,
-            global::Ollama.ResponseFormat? format = default,
-            global::Ollama.RequestOptions? options = default,
             bool? stream = default,
+            global::Ollama.ResponseFormat? format = default,
             int? keepAlive = default,
             global::System.Collections.Generic.IList<global::Ollama.Tool>? tools = default,
+            global::Ollama.RequestOptions? options = default,
+            bool? think = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }
 }

--- a/src/libs/Ollama/Generated/Ollama.ICompletionsClient.GenerateCompletion.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.ICompletionsClient.GenerateCompletion.g.cs
@@ -31,9 +31,6 @@ namespace Ollama
         /// <param name="suffix">
         /// The text that comes after the inserted text.
         /// </param>
-        /// <param name="images">
-        /// (optional) a list of Base64-encoded images to include in the message (for multimodal models such as llava)
-        /// </param>
         /// <param name="system">
         /// The system prompt to (overrides what is defined in the Modelfile).
         /// </param>
@@ -43,18 +40,15 @@ namespace Ollama
         /// <param name="context">
         /// The context parameter returned from a previous request to [generateCompletion], this can be used to keep a short conversational memory.
         /// </param>
-        /// <param name="options">
-        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
-        /// </param>
-        /// <param name="format"></param>
-        /// <param name="raw">
-        /// If `true` no formatting will be applied to the prompt and no context will be returned. <br/>
-        /// You may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API, and are managing history yourself.
-        /// </param>
         /// <param name="stream">
         /// If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.<br/>
         /// Default Value: true
         /// </param>
+        /// <param name="raw">
+        /// If `true` no formatting will be applied to the prompt and no context will be returned. <br/>
+        /// You may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API, and are managing history yourself.
+        /// </param>
+        /// <param name="format"></param>
         /// <param name="keepAlive">
         /// How long (in minutes) to keep the model loaded in memory.<br/>
         /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.<br/>
@@ -62,21 +56,34 @@ namespace Ollama
         /// - If set to 0, the model will be unloaded immediately once finished.<br/>
         /// - If not set, the model will stay loaded for 5 minutes by default
         /// </param>
+        /// <param name="images">
+        /// (optional) a list of Base64-encoded images to include in the message (for multimodal models such as llava)
+        /// </param>
+        /// <param name="options">
+        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
+        /// </param>
+        /// <param name="think">
+        /// Think controls whether thinking/reasoning models will think before<br/>
+        /// responding. Needs to be a pointer so we can distinguish between false<br/>
+        /// (request that thinking _not_ be used) and unset (use the old behavior<br/>
+        /// before this option was introduced).
+        /// </param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         global::System.Collections.Generic.IAsyncEnumerable<global::Ollama.GenerateCompletionResponse> GenerateCompletionAsync(
             string model,
             string prompt,
             string? suffix = default,
-            global::System.Collections.Generic.IList<string>? images = default,
             string? system = default,
             string? template = default,
             global::System.Collections.Generic.IList<long>? context = default,
-            global::Ollama.RequestOptions? options = default,
-            global::Ollama.ResponseFormat? format = default,
-            bool? raw = default,
             bool? stream = default,
+            bool? raw = default,
+            global::Ollama.ResponseFormat? format = default,
             int? keepAlive = default,
+            global::System.Collections.Generic.IList<string>? images = default,
+            global::Ollama.RequestOptions? options = default,
+            bool? think = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }
 }

--- a/src/libs/Ollama/Generated/Ollama.JsonSerializerContextTypes.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.JsonSerializerContextTypes.g.cs
@@ -34,43 +34,43 @@ namespace Ollama
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<string>? Type2 { get; set; }
+        public global::System.Collections.Generic.IList<long>? Type2 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<long>? Type3 { get; set; }
+        public long? Type3 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public long? Type4 { get; set; }
+        public bool? Type4 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.RequestOptions? Type5 { get; set; }
+        public global::Ollama.ResponseFormat? Type5 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public int? Type6 { get; set; }
+        public global::Ollama.ResponseFormatEnum? Type6 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public float? Type7 { get; set; }
+        public object? Type7 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public bool? Type8 { get; set; }
+        public int? Type8 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.ResponseFormat? Type9 { get; set; }
+        public global::System.Collections.Generic.IList<string>? Type9 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Ollama.ResponseFormatEnum? Type10 { get; set; }
+        public global::Ollama.RequestOptions? Type10 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public object? Type11 { get; set; }
+        public float? Type11 { get; set; }
         /// <summary>
         /// 
         /// </summary>

--- a/src/libs/Ollama/Generated/Ollama.Models.GenerateChatCompletionRequest.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.Models.GenerateChatCompletionRequest.g.cs
@@ -26,24 +26,18 @@ namespace Ollama
         public required global::System.Collections.Generic.IList<global::Ollama.Message> Messages { get; set; }
 
         /// <summary>
-        /// 
-        /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("format")]
-        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Ollama.JsonConverters.ResponseFormatJsonConverter))]
-        public global::Ollama.ResponseFormat? Format { get; set; }
-
-        /// <summary>
-        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
-        /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("options")]
-        public global::Ollama.RequestOptions? Options { get; set; }
-
-        /// <summary>
         /// If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.<br/>
         /// Default Value: true
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("stream")]
         public bool? Stream { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("format")]
+        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Ollama.JsonConverters.ResponseFormatJsonConverter))]
+        public global::Ollama.ResponseFormat? Format { get; set; }
 
         /// <summary>
         /// How long (in minutes) to keep the model loaded in memory.<br/>
@@ -62,6 +56,21 @@ namespace Ollama
         public global::System.Collections.Generic.IList<global::Ollama.Tool>? Tools { get; set; }
 
         /// <summary>
+        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("options")]
+        public global::Ollama.RequestOptions? Options { get; set; }
+
+        /// <summary>
+        /// Think controls whether thinking/reasoning models will think before<br/>
+        /// responding. Needs to be a pointer so we can distinguish between false<br/>
+        /// (request that thinking _not_ be used) and unset (use the old behavior<br/>
+        /// before this option was introduced).
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("think")]
+        public bool? Think { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -78,14 +87,11 @@ namespace Ollama
         /// <param name="messages">
         /// The messages of the chat, this can be used to keep a chat memory
         /// </param>
-        /// <param name="format"></param>
-        /// <param name="options">
-        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
-        /// </param>
         /// <param name="stream">
         /// If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.<br/>
         /// Default Value: true
         /// </param>
+        /// <param name="format"></param>
         /// <param name="keepAlive">
         /// How long (in minutes) to keep the model loaded in memory.<br/>
         /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.<br/>
@@ -96,25 +102,36 @@ namespace Ollama
         /// <param name="tools">
         /// A list of tools the model may call.
         /// </param>
+        /// <param name="options">
+        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
+        /// </param>
+        /// <param name="think">
+        /// Think controls whether thinking/reasoning models will think before<br/>
+        /// responding. Needs to be a pointer so we can distinguish between false<br/>
+        /// (request that thinking _not_ be used) and unset (use the old behavior<br/>
+        /// before this option was introduced).
+        /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
         public GenerateChatCompletionRequest(
             string model,
             global::System.Collections.Generic.IList<global::Ollama.Message> messages,
-            global::Ollama.ResponseFormat? format,
-            global::Ollama.RequestOptions? options,
             bool? stream,
+            global::Ollama.ResponseFormat? format,
             int? keepAlive,
-            global::System.Collections.Generic.IList<global::Ollama.Tool>? tools)
+            global::System.Collections.Generic.IList<global::Ollama.Tool>? tools,
+            global::Ollama.RequestOptions? options,
+            bool? think)
         {
             this.Model = model ?? throw new global::System.ArgumentNullException(nameof(model));
             this.Messages = messages ?? throw new global::System.ArgumentNullException(nameof(messages));
-            this.Format = format;
-            this.Options = options;
             this.Stream = stream;
+            this.Format = format;
             this.KeepAlive = keepAlive;
             this.Tools = tools;
+            this.Options = options;
+            this.Think = think;
         }
 
         /// <summary>

--- a/src/libs/Ollama/Generated/Ollama.Models.GenerateCompletionRequest.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.Models.GenerateCompletionRequest.g.cs
@@ -34,12 +34,6 @@ namespace Ollama
         public string? Suffix { get; set; }
 
         /// <summary>
-        /// (optional) a list of Base64-encoded images to include in the message (for multimodal models such as llava)
-        /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("images")]
-        public global::System.Collections.Generic.IList<string>? Images { get; set; }
-
-        /// <summary>
         /// The system prompt to (overrides what is defined in the Modelfile).
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("system")]
@@ -58,17 +52,11 @@ namespace Ollama
         public global::System.Collections.Generic.IList<long>? Context { get; set; }
 
         /// <summary>
-        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
+        /// If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.<br/>
+        /// Default Value: true
         /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("options")]
-        public global::Ollama.RequestOptions? Options { get; set; }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("format")]
-        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Ollama.JsonConverters.ResponseFormatJsonConverter))]
-        public global::Ollama.ResponseFormat? Format { get; set; }
+        [global::System.Text.Json.Serialization.JsonPropertyName("stream")]
+        public bool? Stream { get; set; }
 
         /// <summary>
         /// If `true` no formatting will be applied to the prompt and no context will be returned. <br/>
@@ -78,11 +66,11 @@ namespace Ollama
         public bool? Raw { get; set; }
 
         /// <summary>
-        /// If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.<br/>
-        /// Default Value: true
+        /// 
         /// </summary>
-        [global::System.Text.Json.Serialization.JsonPropertyName("stream")]
-        public bool? Stream { get; set; }
+        [global::System.Text.Json.Serialization.JsonPropertyName("format")]
+        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Ollama.JsonConverters.ResponseFormatJsonConverter))]
+        public global::Ollama.ResponseFormat? Format { get; set; }
 
         /// <summary>
         /// How long (in minutes) to keep the model loaded in memory.<br/>
@@ -93,6 +81,27 @@ namespace Ollama
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("keep_alive")]
         public int? KeepAlive { get; set; }
+
+        /// <summary>
+        /// (optional) a list of Base64-encoded images to include in the message (for multimodal models such as llava)
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("images")]
+        public global::System.Collections.Generic.IList<string>? Images { get; set; }
+
+        /// <summary>
+        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("options")]
+        public global::Ollama.RequestOptions? Options { get; set; }
+
+        /// <summary>
+        /// Think controls whether thinking/reasoning models will think before<br/>
+        /// responding. Needs to be a pointer so we can distinguish between false<br/>
+        /// (request that thinking _not_ be used) and unset (use the old behavior<br/>
+        /// before this option was introduced).
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("think")]
+        public bool? Think { get; set; }
 
         /// <summary>
         /// Additional properties that are not explicitly defined in the schema
@@ -115,9 +124,6 @@ namespace Ollama
         /// <param name="suffix">
         /// The text that comes after the inserted text.
         /// </param>
-        /// <param name="images">
-        /// (optional) a list of Base64-encoded images to include in the message (for multimodal models such as llava)
-        /// </param>
         /// <param name="system">
         /// The system prompt to (overrides what is defined in the Modelfile).
         /// </param>
@@ -127,24 +133,33 @@ namespace Ollama
         /// <param name="context">
         /// The context parameter returned from a previous request to [generateCompletion], this can be used to keep a short conversational memory.
         /// </param>
-        /// <param name="options">
-        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
-        /// </param>
-        /// <param name="format"></param>
-        /// <param name="raw">
-        /// If `true` no formatting will be applied to the prompt and no context will be returned. <br/>
-        /// You may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API, and are managing history yourself.
-        /// </param>
         /// <param name="stream">
         /// If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.<br/>
         /// Default Value: true
         /// </param>
+        /// <param name="raw">
+        /// If `true` no formatting will be applied to the prompt and no context will be returned. <br/>
+        /// You may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API, and are managing history yourself.
+        /// </param>
+        /// <param name="format"></param>
         /// <param name="keepAlive">
         /// How long (in minutes) to keep the model loaded in memory.<br/>
         /// - If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.<br/>
         /// - If set to a negative duration (e.g. -1), the model will stay loaded indefinitely.<br/>
         /// - If set to 0, the model will be unloaded immediately once finished.<br/>
         /// - If not set, the model will stay loaded for 5 minutes by default
+        /// </param>
+        /// <param name="images">
+        /// (optional) a list of Base64-encoded images to include in the message (for multimodal models such as llava)
+        /// </param>
+        /// <param name="options">
+        /// Additional model parameters listed in the documentation for the Modelfile such as `temperature`.
+        /// </param>
+        /// <param name="think">
+        /// Think controls whether thinking/reasoning models will think before<br/>
+        /// responding. Needs to be a pointer so we can distinguish between false<br/>
+        /// (request that thinking _not_ be used) and unset (use the old behavior<br/>
+        /// before this option was introduced).
         /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
@@ -153,28 +168,30 @@ namespace Ollama
             string model,
             string prompt,
             string? suffix,
-            global::System.Collections.Generic.IList<string>? images,
             string? system,
             string? template,
             global::System.Collections.Generic.IList<long>? context,
-            global::Ollama.RequestOptions? options,
-            global::Ollama.ResponseFormat? format,
-            bool? raw,
             bool? stream,
-            int? keepAlive)
+            bool? raw,
+            global::Ollama.ResponseFormat? format,
+            int? keepAlive,
+            global::System.Collections.Generic.IList<string>? images,
+            global::Ollama.RequestOptions? options,
+            bool? think)
         {
             this.Model = model ?? throw new global::System.ArgumentNullException(nameof(model));
             this.Prompt = prompt ?? throw new global::System.ArgumentNullException(nameof(prompt));
             this.Suffix = suffix;
-            this.Images = images;
             this.System = system;
             this.Template = template;
             this.Context = context;
-            this.Options = options;
-            this.Format = format;
-            this.Raw = raw;
             this.Stream = stream;
+            this.Raw = raw;
+            this.Format = format;
             this.KeepAlive = keepAlive;
+            this.Images = images;
+            this.Options = options;
+            this.Think = think;
         }
 
         /// <summary>

--- a/src/libs/Ollama/Generated/Ollama.Models.GenerateCompletionResponse.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.Models.GenerateCompletionResponse.g.cs
@@ -32,6 +32,12 @@ namespace Ollama
         public string? Response { get; set; }
 
         /// <summary>
+        /// Contains the text that was inside thinking tags in the original model output when `think` is enabled.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("thinking")]
+        public string? Thinking { get; set; }
+
+        /// <summary>
         /// Whether the response has completed.<br/>
         /// Example: true
         /// </summary>
@@ -116,6 +122,9 @@ namespace Ollama
         /// The response for a given prompt with a provided model.<br/>
         /// Example: The sky appears blue because of a phenomenon called Rayleigh scattering.
         /// </param>
+        /// <param name="thinking">
+        /// Contains the text that was inside thinking tags in the original model output when `think` is enabled.
+        /// </param>
         /// <param name="done">
         /// Whether the response has completed.<br/>
         /// Example: true
@@ -155,6 +164,7 @@ namespace Ollama
             string? model,
             global::System.DateTime? createdAt,
             string? response,
+            string? thinking,
             bool? done,
             global::System.Collections.Generic.IList<long>? context,
             long? totalDuration,
@@ -167,6 +177,7 @@ namespace Ollama
             this.Model = model;
             this.CreatedAt = createdAt;
             this.Response = response;
+            this.Thinking = thinking;
             this.Done = done;
             this.Context = context;
             this.TotalDuration = totalDuration;

--- a/src/libs/Ollama/Generated/Ollama.Models.Message.g.cs
+++ b/src/libs/Ollama/Generated/Ollama.Models.Message.g.cs
@@ -26,6 +26,12 @@ namespace Ollama
         public required string Content { get; set; }
 
         /// <summary>
+        /// Contains the text that was inside thinking tags in the original model output when `think` is enabled.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("thinking")]
+        public string? Thinking { get; set; }
+
+        /// <summary>
         /// (optional) a list of Base64-encoded images to include in the message (for multimodal models such as llava)
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("images")]
@@ -53,6 +59,9 @@ namespace Ollama
         /// The content of the message<br/>
         /// Example: Why is the sky blue?
         /// </param>
+        /// <param name="thinking">
+        /// Contains the text that was inside thinking tags in the original model output when `think` is enabled.
+        /// </param>
         /// <param name="images">
         /// (optional) a list of Base64-encoded images to include in the message (for multimodal models such as llava)
         /// </param>
@@ -65,11 +74,13 @@ namespace Ollama
         public Message(
             global::Ollama.MessageRole role,
             string content,
+            string? thinking,
             global::System.Collections.Generic.IList<string>? images,
             global::System.Collections.Generic.IList<global::Ollama.ToolCall>? toolCalls)
         {
             this.Role = role;
             this.Content = content ?? throw new global::System.ArgumentNullException(nameof(content));
+            this.Thinking = thinking;
             this.Images = images;
             this.ToolCalls = toolCalls;
         }

--- a/src/libs/Ollama/openapi.yaml
+++ b/src/libs/Ollama/openapi.yaml
@@ -266,13 +266,6 @@ components:
         suffix:
           type: string
           description: The text that comes after the inserted text.
-        images:
-          type: array
-          items:
-            type: string
-            description: Base64-encoded image (for multimodal models such as llava)
-            example: iVBORw0KGgoAAAANSUhEUgAAAAkAAAANCAIAAAD0YtNRAAAABnRSTlMA/AD+APzoM1ogAAAAWklEQVR4AWP48+8PLkR7uUdzcMvtU8EhdykHKAciEXL3pvw5FQIURaBDJkARoDhY3zEXiCgCHbNBmAlUiyaBkENoxZSDWnOtBmoAQu7TnT+3WuDOA7KBIkAGAGwiNeqjusp/AAAAAElFTkSuQmCC
-          description: (optional) a list of Base64-encoded images to include in the message (for multimodal models such as llava)
         system:
           type: string
           description: The system prompt to (overrides what is defined in the Modelfile).
@@ -285,20 +278,31 @@ components:
             type: integer
             format: int64
           description: 'The context parameter returned from a previous request to [generateCompletion], this can be used to keep a short conversational memory.'
-        options:
-          $ref: '#/components/schemas/RequestOptions'
-        format:
-          $ref: '#/components/schemas/ResponseFormat'
-        raw:
-          type: boolean
-          description: "If `true` no formatting will be applied to the prompt and no context will be returned. \n\nYou may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API, and are managing history yourself.\n"
         stream:
           type: boolean
           description: "If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.\n"
           default: true
+        raw:
+          type: boolean
+          description: "If `true` no formatting will be applied to the prompt and no context will be returned. \n\nYou may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API, and are managing history yourself.\n"
+        format:
+          $ref: '#/components/schemas/ResponseFormat'
         keep_alive:
           type: integer
           description: "How long (in minutes) to keep the model loaded in memory.\n\n- If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.\n- If set to a negative duration (e.g. -1), the model will stay loaded indefinitely.\n- If set to 0, the model will be unloaded immediately once finished.\n- If not set, the model will stay loaded for 5 minutes by default\n"
+          nullable: true
+        images:
+          type: array
+          items:
+            type: string
+            description: Base64-encoded image (for multimodal models such as llava)
+            example: iVBORw0KGgoAAAANSUhEUgAAAAkAAAANCAIAAAD0YtNRAAAABnRSTlMA/AD+APzoM1ogAAAAWklEQVR4AWP48+8PLkR7uUdzcMvtU8EhdykHKAciEXL3pvw5FQIURaBDJkARoDhY3zEXiCgCHbNBmAlUiyaBkENoxZSDWnOtBmoAQu7TnT+3WuDOA7KBIkAGAGwiNeqjusp/AAAAAElFTkSuQmCC
+          description: (optional) a list of Base64-encoded images to include in the message (for multimodal models such as llava)
+        options:
+          $ref: '#/components/schemas/RequestOptions'
+        think:
+          type: boolean
+          description: "Think controls whether thinking/reasoning models will think before\nresponding. Needs to be a pointer so we can distinguish between false\n(request that thinking _not_ be used) and unset (use the old behavior\nbefore this option was introduced).\n"
           nullable: true
       description: Request class for the generate endpoint.
     RequestOptions:
@@ -468,6 +472,9 @@ components:
           type: string
           description: The response for a given prompt with a provided model.
           example: The sky appears blue because of a phenomenon called Rayleigh scattering.
+        thinking:
+          type: string
+          description: "Contains the text that was inside thinking tags in the original model output when `think` is enabled.\n"
         done:
           type: boolean
           description: Whether the response has completed.
@@ -526,14 +533,12 @@ components:
           items:
             $ref: '#/components/schemas/Message'
           description: 'The messages of the chat, this can be used to keep a chat memory'
-        format:
-          $ref: '#/components/schemas/ResponseFormat'
-        options:
-          $ref: '#/components/schemas/RequestOptions'
         stream:
           type: boolean
           description: "If `false` the response will be returned as a single response object, otherwise the response will be streamed as a series of objects.\n"
           default: true
+        format:
+          $ref: '#/components/schemas/ResponseFormat'
         keep_alive:
           type: integer
           description: "How long (in minutes) to keep the model loaded in memory.\n\n- If set to a positive duration (e.g. 20), the model will stay loaded for the provided duration.\n- If set to a negative duration (e.g. -1), the model will stay loaded indefinitely.\n- If set to 0, the model will be unloaded immediately once finished.\n- If not set, the model will stay loaded for 5 minutes by default\n"
@@ -543,6 +548,12 @@ components:
           items:
             $ref: '#/components/schemas/Tool'
           description: A list of tools the model may call.
+        options:
+          $ref: '#/components/schemas/RequestOptions'
+        think:
+          type: boolean
+          description: "Think controls whether thinking/reasoning models will think before\nresponding. Needs to be a pointer so we can distinguish between false\n(request that thinking _not_ be used) and unset (use the old behavior\nbefore this option was introduced).\n"
+          nullable: true
       description: Request class for the chat endpoint.
     GenerateChatCompletionResponse:
       required:
@@ -625,6 +636,9 @@ components:
           type: string
           description: The content of the message
           example: Why is the sky blue?
+        thinking:
+          type: string
+          description: "Contains the text that was inside thinking tags in the original model output when `think` is enabled.\n"
         images:
           type: array
           items:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for a "thinking" mode in API requests and responses, allowing models to indicate when they are reasoning before replying.
	- Introduced the ability to include images in completion requests.
- **Enhancements**
	- Improved clarity and consistency in API request and response schemas through property reordering and updated descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->